### PR TITLE
Corretta priorità GameManager:

### DIFF
--- a/ClassPrj/Assets/_Game/Scripts/ControllerAI/FSM.cs
+++ b/ClassPrj/Assets/_Game/Scripts/ControllerAI/FSM.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using UnityEngine;
+﻿using UnityEngine;
 
 /// <summary>
 /// cervello
@@ -7,7 +6,7 @@ using UnityEngine;
 [RequireComponent(typeof(NavMeshAgent)),
     RequireComponent(typeof(Animator))]
 public class FSM : MonoBehaviour
-{   
+{
     public float quantoCiVedoSenzaOcchiali = 10f;
     public float alphaGrad = 140f;
     public bool visualizzaHandleVista = true;
@@ -52,21 +51,20 @@ public class FSM : MonoBehaviour
         }
     }
 
+    public int IndexPercorso
+    {
+        get
+        {
+            return indexPercorso;
+        }
 
-   
-public int IndexPercorso
-{
-   get
-   {
-       return indexPercorso;
-   }
-
-   set
-   {    if (value < 0) indexPercorso = -1;   
+        set
+        {
+            if (value < 0) indexPercorso = -1;
             else
                 indexPercorso = value;
-   }
-}
+        }
+    }
 
     private void Start()
     {
@@ -75,25 +73,15 @@ public int IndexPercorso
         inZonaAttacco = false;
         colliderSferaVista = GetComponentInChildren<SphereCollider>();
         colliderSferaVista.radius = quantoCiVedoSenzaOcchiali;
-         pattugliamento = new Pattugliamento();
+        pattugliamento = new Pattugliamento();
         inseguimento = new Inseguimento();
-          Attacco = new Attacco();
-         Attacco.Inizializza(this);
-        if (Statici.sonoPassatoDallaScenaIniziale)
-            pattugliamento.Inizializza(this);
-        else StartCoroutine(AspettoEInizializzo());
-
+        Attacco = new Attacco();
+        Attacco.Inizializza(this);
+        pattugliamento.Inizializza(this);
         inseguimento.Inizializza(this);
         statoCorrente = pattugliamento;
-        
     }
-    IEnumerator AspettoEInizializzo()
-    {
-        yield return new WaitForSeconds(1f);
-        pattugliamento.Inizializza(this);
 
-
-    }
     private void Update()
     {
         if (statoCorrente != statoPrecedente)
@@ -108,14 +96,14 @@ public int IndexPercorso
         {
             if (!inZonaAttacco)
                 statoCorrente = inseguimento;
-          else
-                 statoCorrente = Attacco; 
-        }
             else
-        { 
-                statoCorrente = pattugliamento;
+                statoCorrente = Attacco;
+        }
+        else
+        {
+            statoCorrente = pattugliamento;
             inZonaAttacco = false;
-             }
+        }
         statoCorrente.Esecuzione();
         Debug.Log("inzona attacco" + inZonaAttacco);
     }

--- a/ClassPrj/Assets/_Game/Scripts/GameManager.cs.meta
+++ b/ClassPrj/Assets/_Game/Scripts/GameManager.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: 3a425bb679279a745b056cda1999f111
-timeCreated: 1451413338
+timeCreated: 1454678698
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -50
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
 per evitare che l'inizializza del pattugliamento venisse eseguito prima dello start del gamemanager, tolto il ritardo che era solo un paliativo.

closes #143
