### PR TITLE
Parti in comune tra script manager iniziale e gamemanager riunificabili:

### DIFF
--- a/ClassPrj/Assets/_Game/Scripts/GameManager.cs
+++ b/ClassPrj/Assets/_Game/Scripts/GameManager.cs
@@ -1,8 +1,13 @@
 ﻿using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
+
+public enum NomeClasse
+{
+    GameManager,
+    ManagerIniziale
+}
 
 public class GameManager : MonoBehaviour
 {
@@ -16,12 +21,11 @@ public class GameManager : MonoBehaviour
 
     //fare dizionari indici...stringa e numerico dizionario
     public static Dictionary<string, List<string>> dizionarioDiNemici = new Dictionary<string, List<string>>();
+
     public static Dictionary<string, List<string>> dizionarioDiAmici = new Dictionary<string, List<string>>();
     public static Dictionary<string, List<string>> dizionarioDiIndifferenti = new Dictionary<string, List<string>>();
     public GameData databseInizialeAmicizie;
     public caratteristichePersonaggioV2 databaseInizialeProprieta;
-
-
 
     private static GameManager me;
     private Serializzabile<AmicizieSerializzabili> datiDiplomazia;
@@ -155,7 +159,7 @@ public class GameManager : MonoBehaviour
             //il personaggio verrà caricato sempre nella scena in cui si è fatto play.
             //N.B. se si vuole provare il salvataggio dell'ultima scena bisogna però fare la trafila a partire dalla prima scena
             //perchè questo else caricherà il personaggio solo nella scena in cui viene fatto play.(per maggiori info chiedere a Ninfea)
-            Metodo_Charlie();
+            Statici.Metodo_Charlie(ref databseInizialeAmicizie, ref databaseInizialeProprieta);
             Statici.nomePersonaggio = "PersonaggioDiProva";
 
             datiPersonaggio = new Serializzabile<ValoriPersonaggioS>(Statici.NomeFilePersonaggio);
@@ -167,7 +171,6 @@ public class GameManager : MonoBehaviour
                 datiPersonaggio.Dati.difesa = 5;
                 datiPersonaggio.Dati.Xp = 19;
                 datiPersonaggio.Dati.Livello = 1;
-
 
                 datiPersonaggio.Dati.nomeModello = "MagoBluM";
 
@@ -201,7 +204,7 @@ public class GameManager : MonoBehaviour
 
                 datiDiplomazia.Salva();
             }
-            SerializzaPercorsi();
+            Statici.SerializzaPercorsi(ref databseInizialeAmicizie, ref datiDiplomazia, ref dizionarioPercorsi);
             Instantiate(Resources.Load(datiPersonaggio.Dati.nomeModello), GameObject.Find(datiPersonaggio.Dati.posizioneCheckPoint).transform.position, Quaternion.identity);
             RecuperaDizionariDiplomazia();
             VitaMassima = datiPersonaggio.Dati.VitaMassima;
@@ -214,60 +217,8 @@ public class GameManager : MonoBehaviour
             Statici.CopiaIlDB();
             Statici.sonoPassatoDallaScenaIniziale = true;
         }
-
     }
 
-    private void SerializzaPercorsi()   //Controlla e se necessario riserializza i percorsi
-    {
-        //Controlla i percorsi se sono gia serializzati e se ci sono variazioni li reserializza
-        //se non sono serializzati li serializza
-        //se non ci sono variazioni non fa niente
-
-        if (databseInizialeAmicizie == null) return;
-
-        if (datiDiplomazia == null)
-
-            datiDiplomazia = new Serializzabile<AmicizieSerializzabili>(Statici.nomeFileDiplomazia);
-
-        if (datiDiplomazia.Dati.indexPercorsi.Equals(databseInizialeAmicizie.indexPercorsi)) return;  //CONTROLLARE SE METODO E' CORRETTO
-
-        for (int i = 0; i < databseInizialeAmicizie.tagEssere.Length; i++)
-
-        {
-            datiDiplomazia.Dati.indexPercorsi[i] = databseInizialeAmicizie.indexPercorsi[i];
-        }
-
-        datiDiplomazia.Salva();
-
-        // AGGIUNTO PER IL DIZIONARIO SUI PERCORSO
-        dizionarioPercorsi.Clear();
-
-        for (int i = 0; i < datiDiplomazia.Dati.tipoEssere.Length; i++)
-            dizionarioPercorsi.Add(datiDiplomazia.Dati.tipoEssere[i], datiDiplomazia.Dati.indexPercorsi[i]);
-
-
-    }
-
-
-    private void Metodo_Charlie()   //metodo per assegnare gli asset dentro l'inspector... By Luca del dftStudent
-    {
-        if (databseInizialeAmicizie == null)
-        {
-            if (EditorPrefs.HasKey(Statici.STR_PercorsoConfig))
-            {
-                string percorso = EditorPrefs.GetString(Statici.STR_PercorsoConfig);
-                databseInizialeAmicizie = AssetDatabase.LoadAssetAtPath<GameData>(percorso + Statici.STR_DatabaseDiGioco);
-            }
-        }
-        if (databaseInizialeProprieta == null)
-        {
-            if (EditorPrefs.HasKey(Statici.STR_PercorsoConfig3))
-            {
-                string percorso = EditorPrefs.GetString(Statici.STR_PercorsoConfig3);
-                databaseInizialeProprieta = AssetDatabase.LoadAssetAtPath<caratteristichePersonaggioV2>(percorso + Statici.STR_DatabaseDiGioco3);
-            }
-        }
-    }
     private void RecuperaDizionariDiplomazia()
     {
         dizionarioDiNemici.Clear();
@@ -352,12 +303,8 @@ public class GameManager : MonoBehaviour
                 }
                 if (attuale.transform.FindChild("quadDiSelezione"))
                     attuale.transform.FindChild("quadDiSelezione").gameObject.SetActive(true);
-
-
             }
         }
-
-
     }
 
     public static void DichiaroGuerra()
@@ -415,13 +362,11 @@ public class GameManager : MonoBehaviour
     public static void RiceviDanno()
     {
         VitaAttuale -= 1f;
-
     }
 
     public static void PozioneVita()
     {
         VitaAttuale += 1f;
-
     }
 
     public static void MemorizzaCheckPoint(string nomeCheckPoint)

--- a/ClassPrj/Assets/_Game/Scripts/ManagerIniziale.cs
+++ b/ClassPrj/Assets/_Game/Scripts/ManagerIniziale.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -14,6 +13,7 @@ internal enum Sesso
 
 public class ManagerIniziale : MonoBehaviour
 {
+    private static ManagerIniziale me;
     public Animator AnimatoreMenu;
     public Animator AltrieMenu1;
     public Animator AltrieMenu2;
@@ -88,33 +88,15 @@ public class ManagerIniziale : MonoBehaviour
         }
     }
 
-    private void Metodo_Charlie()   //metodo per assegnare gli asset dentro l'inspector... By Luca del dftStudent
-    {
-        if (databseInizialeAmicizie == null)
-        {
-            if (EditorPrefs.HasKey(Statici.STR_PercorsoConfig))
-            {
-                string percorso = EditorPrefs.GetString(Statici.STR_PercorsoConfig);
-                databseInizialeAmicizie = AssetDatabase.LoadAssetAtPath<GameData>(percorso + Statici.STR_DatabaseDiGioco);
-            }
-        }
-        if (databaseInizialeProprieta == null)
-        {
-            if (EditorPrefs.HasKey(Statici.STR_PercorsoConfig3))
-            {
-                string percorso = EditorPrefs.GetString(Statici.STR_PercorsoConfig3);
-                databaseInizialeProprieta = AssetDatabase.LoadAssetAtPath<caratteristichePersonaggioV2>(percorso + Statici.STR_DatabaseDiGioco3);
-            }
-        }
-    }
-
     // Use this for initialization
     private void Start()
     {
+        me = this;
         nomeScenaText.gameObject.SetActive(false);
-#if UNITY_EDITOR
-        Metodo_Charlie();
-#endif
+        //#if UNITY_EDITOR
+
+        Statici.Metodo_Charlie(ref databseInizialeAmicizie, ref databaseInizialeProprieta);
+        //#endif
 
         Me = this;
         cameraT = Camera.main.transform;
@@ -151,7 +133,7 @@ public class ManagerIniziale : MonoBehaviour
 
     public void CaricaScena()
     {
-        Statici.sonoPassatoDallaScenaIniziale = true; //+
+        Statici.sonoPassatoDallaScenaIniziale = true;
 
         for (int i = 0; i < databaseInizialeProprieta.matriceProprieta.Count; i++)
         {
@@ -159,11 +141,11 @@ public class ManagerIniziale : MonoBehaviour
             Destroy(GameObject.Find(databaseInizialeProprieta.matriceProprieta[i].nomeF + "(Clone)"));
         }
 
-        SerializzaPercorsi();
+        Statici.SerializzaPercorsi(ref databseInizialeAmicizie, ref datiDiplomazia, ref GameManager.dizionarioPercorsi);
         /*
-        l'if else qui sotto, serve per verificare se la scena in cui vogliamo far spuntare il personaggio 
+        l'if else qui sotto, serve per verificare se la scena in cui vogliamo far spuntare il personaggio
         esiste ancora o no nel build settings. Perchè può capitare di cancellar euna scena o rinominalrla.
-        Per evitare di far andar ein errore il gioco, se la scena non esiste più il personaggio viene caricato 
+        Per evitare di far andar ein errore il gioco, se la scena non esiste più il personaggio viene caricato
         nell'isola altrimenti nell'ultima scena visitata.
         */
 
@@ -176,7 +158,6 @@ public class ManagerIniziale : MonoBehaviour
         }
         else
             SceneManager.LoadScene(datiPersonaggio.Dati.nomeScena);
-
     }
 
     public void AvviaGioco()
@@ -252,41 +233,9 @@ public class ManagerIniziale : MonoBehaviour
 
             datiDiplomazia.Salva();
         }
-        SerializzaPercorsi();
+        Statici.SerializzaPercorsi(ref databseInizialeAmicizie, ref datiDiplomazia, ref GameManager.dizionarioPercorsi);
         personaggiInCarica = true;
         SceneManager.LoadScene(datiPersonaggio.Dati.nomeScena);
-
-    }
-
-    private void SerializzaPercorsi()   //Controlla e se necessario riserializza i percorsi
-    {
-        //Controlla i percorsi se sono gia serializzati e se ci sono variazioni li reserializza
-        //se non sono serializzati li serializza
-        //se non ci sono variazioni non fa niente
-
-        if (databseInizialeAmicizie == null) return;
-
-        if (datiDiplomazia == null)
-
-            datiDiplomazia = new Serializzabile<AmicizieSerializzabili>(Statici.nomeFileDiplomazia);
-
-        if (datiDiplomazia.Dati.indexPercorsi.Equals(databseInizialeAmicizie.indexPercorsi)) return;  //CONTROLLARE SE METODO E' CORRETTO
-
-        for (int i = 0; i < databseInizialeAmicizie.tagEssere.Length; i++)
-
-        {
-            datiDiplomazia.Dati.indexPercorsi[i] = databseInizialeAmicizie.indexPercorsi[i];
-        }
-
-        datiDiplomazia.Salva();
-
-        // AGGIUNTO PER IL DIZIONARIO SUI PERCORSO
-        GameManager.dizionarioPercorsi.Clear();
-
-        for (int i = 0; i < datiDiplomazia.Dati.tipoEssere.Length; i++)
-            GameManager.dizionarioPercorsi.Add(datiDiplomazia.Dati.tipoEssere[i], datiDiplomazia.Dati.indexPercorsi[i]);
-
-
     }
 
     public void Anulla1()
@@ -380,7 +329,6 @@ public class ManagerIniziale : MonoBehaviour
         //mentre sto caricando una nuova scena faccio spuntare un immagine di sfondo e il nome della scena facendo scomparire eventuali pannelli attivi:
         if (Application.isLoadingLevel && pannelloImmagineSfondo.color.a != 1f)
         {
-
             AltrieMenu2.gameObject.SetActive(false);
             AltrieMenu1.gameObject.SetActive(false);
             AnimatoreMenu.gameObject.SetActive(false);
@@ -388,7 +336,6 @@ public class ManagerIniziale : MonoBehaviour
             nomeScenaText.text = "Loading... " + datiPersonaggio.Dati.nomeScena;
             pannelloImmagineSfondo.GetComponent<Image>().color = new Color(1f, 1f, 1f, 1f);
         }
-
     }
 
     private void CambiaPosizioneTelecamera()
@@ -448,7 +395,6 @@ public class ManagerIniziale : MonoBehaviour
             }
             ElencoCartelle.captionText.text = string.Empty;  //NON VISUALIZZA LA STRINGA QUANDO LA LISTA E' VUOTA
         }
-        
     }
 
     public void RecuperaDatiGiocatore()

--- a/ClassPrj/Assets/_Game/Scripts/Statici.cs
+++ b/ClassPrj/Assets/_Game/Scripts/Statici.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using Mono.Data.Sqlite;
+using UnityEditor;
 
 public class Statici
 {
@@ -19,7 +20,7 @@ public class Statici
     public const string STR_PercorsoConfig3 = "PercorsoConfigurazione";
     public const string STR_DatabaseDiGioco3 = "/dataBasePersonaggioV2.asset";
 
-    public static bool sonoPassatoDallaScenaIniziale = false;//+
+    public static bool sonoPassatoDallaScenaIniziale = false;
 
     static string origine = Application.streamingAssetsPath + "/dbgioco.db";
     static string destinazione = Application.persistentDataPath + "/dbgioco.db";
@@ -51,6 +52,66 @@ public class Statici
         {
             Debug.Log("Chiusa!");
         }
+    }
+
+
+    /// <summary>
+    /// Lo script metodo charlie e serializza percorsi sono due metodi statici perchè vengono richiamati
+    /// in due script cioè manager iniziale e gamemanager.
+    /// Per evitare di avere due metodi identici dentro entrambi gli script li ho spostati qui e resi statici
+    /// in modo che siano scritti una volta sola e richiamati dove si vuole.
+    /// </summary>
+    /// <param name="databseInizialeAmicizie"></param>
+    /// <param name="databaseInizialeProprieta"></param>
+    public static void Metodo_Charlie(ref GameData databseInizialeAmicizie,ref caratteristichePersonaggioV2 databaseInizialeProprieta)   //metodo per assegnare gli asset dentro l'inspector... By Luca del dftStudent
+    {
+        if (databseInizialeAmicizie == null)
+        {
+            if (EditorPrefs.HasKey(Statici.STR_PercorsoConfig))
+            {
+                string percorso = EditorPrefs.GetString(Statici.STR_PercorsoConfig);
+                databseInizialeAmicizie = AssetDatabase.LoadAssetAtPath<GameData>(percorso + Statici.STR_DatabaseDiGioco);
+            }
+        }
+        if (databaseInizialeProprieta == null)
+        {
+            if (EditorPrefs.HasKey(Statici.STR_PercorsoConfig3))
+            {
+                string percorso = EditorPrefs.GetString(Statici.STR_PercorsoConfig3);
+                databaseInizialeProprieta = AssetDatabase.LoadAssetAtPath<caratteristichePersonaggioV2>(percorso + Statici.STR_DatabaseDiGioco3);
+            }
+        }
+    }
+
+    public static void SerializzaPercorsi(ref GameData databseInizialeAmicizie, ref Serializzabile<AmicizieSerializzabili> datiDiplomazia, ref Dictionary<string, int> dizionarioPercorsi)   //Controlla e se necessario riserializza i percorsi
+    {
+        //Controlla i percorsi se sono gia serializzati e se ci sono variazioni li reserializza
+        //se non sono serializzati li serializza
+        //se non ci sono variazioni non fa niente
+
+        if (databseInizialeAmicizie == null) return;
+
+        if (datiDiplomazia == null)
+
+            datiDiplomazia = new Serializzabile<AmicizieSerializzabili>(Statici.nomeFileDiplomazia);
+
+        if (datiDiplomazia.Dati.indexPercorsi.Equals(databseInizialeAmicizie.indexPercorsi)) return;  //CONTROLLARE SE METODO E' CORRETTO
+
+        for (int i = 0; i < databseInizialeAmicizie.tagEssere.Length; i++)
+
+        {
+            datiDiplomazia.Dati.indexPercorsi[i] = databseInizialeAmicizie.indexPercorsi[i];
+        }
+
+        datiDiplomazia.Salva();
+
+        // AGGIUNTO PER IL DIZIONARIO SUI PERCORSO
+        dizionarioPercorsi.Clear();
+
+        for (int i = 0; i < datiDiplomazia.Dati.tipoEssere.Length; i++)
+            dizionarioPercorsi.Add(datiDiplomazia.Dati.tipoEssere[i], datiDiplomazia.Dati.indexPercorsi[i]);
+
+
     }
 }
 


### PR DESCRIPTION
i due script hanno due parti uguali ripetute due volte, riunire il tutto sotto un unico metodo statico e richiamare quello nei posti in cui serve.

closes #153
