### PR TITLE
Premendo tasto C cambio la telecamera da nord a sud e viceversa.

### DIFF
--- a/ClassPrj/Assets/_Game/Scene/Castello.unity
+++ b/ClassPrj/Assets/_Game/Scene/Castello.unity
@@ -4124,7 +4124,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22468200, guid: 566cb5b5afc524f4aacdb0e832b67ddc, type: 2}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 145152, guid: 566cb5b5afc524f4aacdb0e832b67ddc, type: 2}
       propertyPath: m_IsActive
@@ -19825,7 +19825,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 10
 --- !u!1 &1025067877
 GameObject:
   m_ObjectHideFlags: 0
@@ -33891,7 +33891,7 @@ Transform:
   - {fileID: 1791844600}
   - {fileID: 936732349}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
 --- !u!1 &1673137285
 GameObject:
   m_ObjectHideFlags: 0
@@ -36143,6 +36143,10 @@ Prefab:
     - target: {fileID: 411376, guid: 61b1ba6df3b86a24180b80a910cbd8bb, type: 2}
       propertyPath: m_LocalPosition.y
       value: -0.058
+      objectReference: {fileID: 0}
+    - target: {fileID: 11456822, guid: 61b1ba6df3b86a24180b80a910cbd8bb, type: 2}
+      propertyPath: destinazione
+      value: Isola
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 61b1ba6df3b86a24180b80a910cbd8bb, type: 2}

--- a/ClassPrj/Assets/_Game/Scripts/Camera/TopDowCamera.cs
+++ b/ClassPrj/Assets/_Game/Scripts/Camera/TopDowCamera.cs
@@ -33,14 +33,12 @@ public class TopDowCamera : MonoBehaviour
             Target = GameObject.FindGameObjectWithTag("Player").GetComponent<Transform>();
         else if (Target != null)
         {
-            Obiettivo = new Vector3(Target.position.x, Target.position.y + altezza, Target.position.z - ZOffSet);
-
+            if (Input.GetKeyDown(KeyCode.C))          
+                ZOffSet *= (-1f);            
+            Obiettivo = new Vector3(Target.position.x, Target.position.y + altezza, Target.position.z + ZOffSet);
             myTransform.position = Vector3.SmoothDamp(myTransform.position, Obiettivo, ref velocita, DampTime);
-
-            if (ZOffSet != 0f)
-            {
-                myTransform.LookAt(Target.position);
-            }
+            if (ZOffSet != 0f)          
+                myTransform.LookAt(Target.position);            
         }
     }
 }


### PR DESCRIPTION
(in accordo con gli altri abbiamo deciso di dare la posibilità al giocatore di inquadrare il personaggio o di spalle o di faccia se esso è girato verso nord o verso sud.)
Corretta anche la destinazione del portale del castello che portava sempre al castello invece che all'isola.

closes #242
